### PR TITLE
Removed the vc9. Minimum requirements for TBB is vc10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 1
   features:
-    - vc10  # [win and py27]
     - vc14  # [win and py>=35]
   skip: true  # [win and py36]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 94f643f1edfaccb57d64b503c7c96f00dec64e8635c054bbaa33855d72c5822d
 
 build:
-  number: 0
+  number: 1
   features:
-    - vc9  # [win and py27]
+    - vc10  # [win and py27]
     - vc14  # [win and py>=35]
   skip: true  # [win and py36]
 


### PR DESCRIPTION
Update the vc9 to vc10, according to the TBB documentation the minimum requirement to build TBB is MSVC2010

https://www.threadingbuildingblocks.org/system-requirements