### PR TITLE
WIP: splitting into 3 tbb packages adding Python module

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 23793c8645480148e9559df96b386b780f92194c80120acce79fcdaae0d81f45
 
 build:
-  number: 0
+  number: 1
   script_env:
     - OS    # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,9 @@
 {% set version = "2018.0.3" %}
 {% set vtag = "2018_U3" %}
-{% set args = " --build-args=stdver=c++11 --install-libs --install-devel --install-docs" %}
-#  no --install-python yet, it will be a separate package
+{% set vinterface = 10003 %}
+
+{% set build = 'python build/build.py --make-tool=mingw32-make --build-prefix=vc%VS_MAJOR%' %}  # [win]
+{% set build = 'python build/build.py --build-args=stdver=c++11' %} # [unix]
 
 package:
   name: tbb
@@ -14,31 +16,86 @@ source:
 
 build:
   number: 0
-  script: python build/build.py {{ args }}                                          # [unix]
-  script: python build/build.py --make-tool=mingw32-make {{ args }}                 # [win]
   script_env:
     - OS    # [win]
-  features:
-    - vc9   # [win and py27]
-    - vc14  # [win and py>=35]
 
 requirements:
   build:
     - toolchain
     - python
     - swig
+    - {{ compiler('cxx') }}  # [win]
     - m2w64-make  # [win]
 
-test:
-  requires:
-    - python
-  commands:
-    - test -f ${PREFIX}/include/tbb/tbb.h  # [unix]
-    - python -c "import ctypes; ctypes.cdll[r'${PREFIX}/lib/libtbb.so.2']"  # [linux]
-    - python -c "import ctypes; ctypes.cdll[r'${PREFIX}/lib/libtbb${SHLIB_EXT}']"  # [unix and not linux]
-    - python -c "import ctypes; ctypes.cdll[r'%PREFIX%\Library\bin\tbb.dll']"  # [win]
-    - if not exist %PREFIX%\\Library\\include\\tbb\\tbb.h exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\tbb.lib exit 1  # [win]
+outputs:
+  - name: tbb
+    build:
+      script: {{ build }} --install-libs
+      features:
+        - vc9   # [win and py27]
+        - vc14  # [win and py>=35]
+      binary_relocation: False
+    test:
+      requires:
+        - python *  # any python version is ok for sake of testing of shared libraries
+      commands:
+        - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'libtbb.so.2']       ['TBB_runtime_interface_version']()"  # [linux]
+        - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'libtbb${SHLIB_EXT}']['TBB_runtime_interface_version']()"  # [unix and not linux]
+        - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'tbb.dll']           ['TBB_runtime_interface_version']()"  # [win]
+
+  - name: tbb-devel
+    build:
+      script: {{ build }} --no-rebuild --install-devel --install-docs
+      features:
+        - vc9   # [win and py27]
+        - vc14  # [win and py>=35]
+      binary_relocation: False
+    requirements:
+      host:
+        - {{ compiler('cxx') }}  # [win]
+        - m2w64-make             # [win]
+      run:
+        - {{ pin_subpackage('tbb', exact=True) }}     # development package is for specific version of tbb
+    test:
+      commands:
+        - if not exist %LIBRARY_INC%\\tbb\\tbb.h exit 1  # [win]
+        - if not exist %LIBRARY_LIB%\\tbb.lib exit 1     # [win]
+        - test -f ${PREFIX}/include/tbb/tbb.h            # [unix]
+
+  - name: tbb4py
+    build:
+      script: {{ build }} --no-rebuild --install-python
+      features:
+        - vc9   # [win and py27]
+        - vc14  # [win and py>=35]
+      entry_points:
+        - python-tbb = tbb:_main
+    requirements:
+      host:
+        - {{ compiler('cxx') }}  # [win]
+        - m2w64-make # [win]
+        - python {{ python }}
+        - swig
+        - {{ pin_subpackage('tbb-devel', exact=True) }}
+      run:
+        - tbb >={{ version }}                          # while python module works with any compatible tbb...
+        - python {{ python }}
+    test:
+      requires:
+        - python {{ python }}
+        - {{ pin_subpackage('tbb', exact=True) }}      # we want to test with this specific tbb package
+      imports:
+        - tbb
+        - TBB
+      commands:
+        - python-tbb -h
+        - python -m TBB -h
+        - python -m tbb -h
+        - python -m tbb test
+    about:
+      summary: TBB module for Python
+      license: Apache 2.0
+      dev_url: https://github.com/01org/tbb
 
 about:
   home: http://www.threadingbuildingblocks.org


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`. There is a problem with conda smithy as it removes desired build configurations
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This splits the tbb package into `tbb`, `tbb-devel`, and adds `tbb4py` package for Python module for TBB.
the recipe was tested with `conda-build . -c conda-forge` on Linux and Windows but since meta.yaml uses compiler and pinning features of conda-build, it might not work with conda smithy and CI environment here.