### PR TITLE
Test Fibonacci on Release configuration

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ package:
 source:
   fn: tbb{{ vtag }}_oss_src.tgz
   url: https://github.com/intel/tbb/archive/{{ vtag }}.tar.gz
-  sha256: 48d51c63b16787af54e1ee4aaf30042087f20564b4eecf9a032d5568bc2f0bf8
+  sha256: 7c96a150ed22bc3c6628bc3fef9ed475c00887b26d37bca61518d76a56510971
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 48d51c63b16787af54e1ee4aaf30042087f20564b4eecf9a032d5568bc2f0bf8
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and py2k]
   script_env:
     - OS    # [win]
@@ -73,8 +73,8 @@ outputs:
         - examples/test_all/fibonacci
       commands:
         - set "CMAKE_GENERATOR=NMake Makefiles"          # [win]
-        - cmake -S examples/test_all/fibonacci -B test-bld
-        - cmake --build test-bld --config release
+        - cmake -S examples/test_all/fibonacci -B test-bld -DCMAKE_BUILD_TYPE=Release
+        - cmake --build test-bld
         - cmake -E env test-bld/fibonacci                # [not win or not py2k]
 
   - name: tbb4py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ package:
 
 source:
   fn: tbb{{ vtag }}_oss_src.tgz
-  url: https://github.com/intel/tbb/archive/{{ vtag }}.tar.gz
+  url: https://github.com/oneapi-src/oneTBB/archive/{{ vtag }}.tar.gz
   sha256: 7c96a150ed22bc3c6628bc3fef9ed475c00887b26d37bca61518d76a56510971
 
 build:
@@ -106,14 +106,14 @@ outputs:
     about:
       summary: TBB module for Python
       license: Apache 2.0
-      dev_url: https://github.com/01org/tbb
+      dev_url: https://github.com/oneapi-src/oneTBB
 
 about:
   home: http://www.threadingbuildingblocks.org
   license: Apache 2.0
   license_file: LICENSE
   summary: High level abstract threading library
-  dev_url: https://github.com/01org/tbb
+  dev_url: https://github.com/oneapi-src/oneTBB
   doc_url: https://software.intel.com/en-us/node/506039
 
 extra:


### PR DESCRIPTION
This patch should fix [failed CI on Windows](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=126754&view=logs&j=f3f71ba1-f87e-5afa-974e-577ff38d9bf3&t=76287061-6748-5183-e373-2833513eaee5). This is a continuation of PR #60.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
