### PR TITLE
Added missed licence files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ source:
     - 0009-fix-unsupported-option-mac.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -64,6 +64,9 @@ outputs:
   - name: tbb
     about:
       summary: TBB Libraries
+      license_file:
+        - LICENSE.txt
+        - third-party-programs.txt
     build:
       script:
         - set CMAKE_GENERATOR=Ninja      # [win]
@@ -90,6 +93,9 @@ outputs:
   - name: tbb-devel
     about:
       summary: TBB Development files
+      license_file:
+        - LICENSE.txt
+        - third-party-programs.txt
     build:
       script:
         - set CMAKE_GENERATOR=Ninja      # [win]
@@ -146,6 +152,9 @@ outputs:
   - name: tbb4py
     about:
       summary: TBB module for Python
+      license_file:
+        - LICENSE.txt
+        - third-party-programs.txt
     build:
       script:
         - set CMAKE_GENERATOR=Ninja      # [win]
@@ -197,3 +206,4 @@ extra:
     - jschueller
     - AlexVeprev
     - isaevil
+    - ilya-lavrenov


### PR DESCRIPTION
Currently, `tbb-devel` and `tbb4py` packages don't contain license files:
<img width="387" alt="Screenshot 2023-09-09 at 2 45 32 PM" src="https://github.com/conda-forge/tbb-feedstock/assets/2566854/d0cb3dac-d321-4e8e-81d9-3d775eb23384">

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.
