### PR TITLE
Respect the `libhwloc` pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ source:
   sha256: f8767b971ec6aea25dde58ae0f593e94e7aa75a739a86f67967012f69e2199b1
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -57,7 +57,7 @@ requirements:
     - cmake
     - pkg-config
   host:
-    - libhwloc >=2.5
+    - libhwloc
 
 outputs:
   - name: tbb
@@ -77,7 +77,7 @@ outputs:
         - cmake -DCOMPONENT=runtime -P build/cmake_install.cmake
     requirements:
       host:
-        - libhwloc >=2.5
+        - libhwloc
     test:
       requires:
         # any python version is ok for sake of testing of shared libraries


### PR DESCRIPTION

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Remove the version specifier from `libhwloc` dependency in order to make the recipe respect the pin from `conda-forge-pinning`.  Otherwise, the recipe pulls the latest version, and the resulting packages are incompatible with the version pinned in other feedstocks, e.g. causing the following failure for `intel-compiler-repack-feedstock`:

```
Could not solve for environment specs
The following packages are incompatible
├─ intel-cmplr-lib-ur 2026.0.0.* h04fd95a_947 is installable and it requires
│  └─ umf 1.1.0 h720b5ae_340, which requires
│     └─ libhwloc >=2.12.2,<2.12.3.0a0  with the potential options
│        ├─ libhwloc [2.12.2|2.13.0] would require
│        │  └─ __cuda, which is missing on the system;
│        └─ libhwloc 2.12.2, which can be installed;
└─ intel-opencl-rt 2026.0.0.* he68e48a_947 is not installable because it requires
   └─ tbb >=2023.0.0 , which requires
      └─ libhwloc >=2.13.0,<2.13.1.0a0  but there are no viable options
         ├─ libhwloc [2.12.2|2.13.0], which cannot be installed (as previously explained);
         └─ libhwloc 2.13.0 conflicts with any installable versions previously reported.
```

I'm sorry for missing this when submitting #160.